### PR TITLE
feat(unique index): added the ability to index object properties as unique

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,40 @@ const createCustomer = (name: string, country: 'US' | 'AU' | 'NZ' | 'UK' | 'FR')
   });
 }
 ```
+
+### Unique indexes that enforce one object per property
+
+What if we wanted to enforce that no two objects have the same property, and look them up by 
+that property? We can do that with a unique index.
+
+```ts
+const [{ statusHashIndex, orderIdUniqueIndex }, 
+  captureOrder] = createIndexes({
+  hash: {targetProperties: ['status']},
+  unique: {targetProperties: ['orderId']}
+});
+
+const exampleOrder = captureOrder({
+  orderId: '123abc',
+  status: 'PLACED',
+  cost: 400
+});
+
+const order = orderIdUniqueIndex.get('123abc')
+
+const duplicateOrder = captureOrder({
+  orderId: '123abc',
+  status: 'SHIPPED',
+  cost: 200
+}); // throws UniqueConstraintViolation!
+
+const updatedDuplicate = captureOrder({
+  orderId: '456zyx',
+  status: 'SHIPPED',
+  cost: 200
+});
+
+updatedDuplicate.orderId = '123abc'; // throws UniqueConstraintViolation!
+
+```
+

--- a/README.md
+++ b/README.md
@@ -150,8 +150,12 @@ What if we wanted to enforce that no two objects have the same property, and loo
 that property? We can do that with a unique index.
 
 ```ts
-const [{ statusHashIndex, orderIdUniqueIndex }, 
-  captureOrder] = createIndexes({
+const [{ 
+    hash: {statusIndex}, 
+    unique: {orderIdIndex} 
+  }, 
+  captureOrder
+] = createIndexes({
   hash: {targetProperties: ['status']},
   unique: {targetProperties: ['orderId']}
 });

--- a/README.md
+++ b/README.md
@@ -9,10 +9,15 @@ a set of orders based on their order status. However, their order status frequen
 Proxy-indexer makes this process transparent via the following API:
 
 ```ts
-import { createHashIndex } from 'proxy-indexer';
+import { createIndexes } from 'proxy-indexer';
 
-const [{ statusIndex: orderStatusIndex }, captureOrder] = createHashIndex({
-  targetProperties: ['status'],
+const [
+  { 
+    hash: { statusIndex: orderStatusIndex } 
+  }, 
+  captureOrder
+] = createIndexes({
+  hash: {targetProperties: ['status']}, 
 });
 
 const exampleOrder = captureOrder({
@@ -38,8 +43,13 @@ When you have thousands of objects and need to look them up by a particular prop
 indexing method is more than 1000x times faster than the alternative -- iterating and filtering.
 
 ```ts
-const [{ statusIndex: orderStatusIndex }, captureOrder] = createHashIndex({
-  targetProperties: ['status'],
+const [
+  {
+    hash: { statusIndex: orderStatusIndex }
+  },
+  captureOrder
+] = createIndexes({
+  hash: {targetProperties: ['status']},
 });
 
 const statusMap = { 0: 'PLACED', 1: 'SHIPPED', 2: 'DELIVERED', 3: 'CANCELLED'};
@@ -93,7 +103,7 @@ Using an index has two steps:
 Let's examine the first step now:
 
 ```ts
-import { createHashIndex } from 'proxy-indexer';
+import { createIndexes } from 'proxy-indexer';
 
 type Customer = {
   name: string;
@@ -102,15 +112,17 @@ type Customer = {
 }
 
 const [
-  { statusIndex, countryIndex }, 
+  {
+    hash: { statusIndex, countryIndex },
+  }, 
   captureCustomer
-] = createHashIndex<Customer>({
-  targetProperties: ['status', 'country'],
-});
+] = createIndexes<Customer>({
+  hash: { targetProperties: ['status', 'country'] },
+}); 
 ```
 
 In the above example we instantiate an index for our customer entity, with indexes on country 
-and status. The `createHashIndex` function returns a tuple containing:
+and status. The `createIndexes` function returns a tuple containing:
 
 * An object containing the indexes, each as a property keyed by `'${targetProperty}Index'`
 * A capture function
@@ -165,6 +177,8 @@ const updatedDuplicate = captureOrder({
 });
 
 updatedDuplicate.orderId = '123abc'; // throws UniqueConstraintViolation!
-
 ```
+
+This is useful when an object has more than one identifier, such as an object that has an ID 
+from a third party system.
 

--- a/src/indexes/common.ts
+++ b/src/indexes/common.ts
@@ -1,3 +1,8 @@
+export type IndexableObj = Record<string, unknown>;
+
+export type TargetProperties = TargetProperty[];
+export type TargetProperty = string;
+
 export type IndexOptions = {
   targetProperties: string[];
 };

--- a/src/indexes/common.ts
+++ b/src/indexes/common.ts
@@ -1,10 +1,21 @@
 export type IndexableObj = Record<string, unknown>;
 
-export type TargetProperties = TargetProperty[];
+export type Properties = string[];
 export type TargetProperty = string;
 
-export type IndexOptions = {
-  targetProperties: string[];
+export type IndexOptions<T extends IndexableObj> = {
+  targetProperties: Properties;
 };
 
-export type Captor<T> = (obj: T) => T;
+export type Captor<T extends IndexableObj> = (obj: T) => T;
+export type Updater<T extends IndexableObj> = (
+  obj: T,
+  propName: string,
+  newValue: T[string]
+) => void;
+export type Ingestor<T extends IndexableObj> = (obj: T) => void;
+
+export class IndexError extends Error {}
+export class MissingIndex extends IndexError {}
+export class MissingIndexValue extends IndexError {}
+export class ConfigurationError extends IndexError {}

--- a/src/indexes/createIndexes.ts
+++ b/src/indexes/createIndexes.ts
@@ -1,63 +1,77 @@
-import { HashIndex, HashIndexOptions } from './hash';
+import { createHashIndex, HashIndex } from './hash';
 import {
   Captor,
+  ConfigurationError,
   IndexableObj,
-  TargetProperties,
-  TargetProperty,
+  IndexOptions,
+  Ingestor,
+  Updater,
 } from './common';
-import { UniqueIndexOptions } from './uniqueHash';
+import { createUniqueHashIndex, UniqueIndex } from './uniqueHash';
 
-type Options = {
-  hash?: HashIndexOptions;
-  unique?: UniqueIndexOptions;
+type Options<T extends IndexableObj> = {
+  hash?: IndexOptions<T>;
+  unique?: IndexOptions<T>;
+};
+
+type Indexes<T extends IndexableObj> = {
+  hash: HashIndex<T>;
+  unique: UniqueIndex<T>;
 };
 
 export function createIndexes<T extends IndexableObj>(
-  opts: Options
-): [HashIndex<T, TargetProperties>, Captor<T>] {
+  opts: Options<T>
+): [Indexes<T>, Captor<T>] {
+  validateOptions(opts);
   const { hash: hashOpts, unique: uniqueOpts } = opts;
-  // create the complete list of target properties
-  // instantiate the indexes
 
-  const captorFunction: Captor<T> = (obj) => {
+  const [hashIdx, updateInHashIndex, ingestIntoHashIndex] = hashOpts
+    ? createHashIndex<T>(hashOpts)
+    : [];
+  const [uniqueIdx, updateInUniqueIndex, ingestIntoUniqueIndex] = uniqueOpts
+    ? createUniqueHashIndex<T>(uniqueOpts)
+    : [];
+
+  const updaters = [updateInUniqueIndex, updateInHashIndex].filter<Updater<T>>(
+    isNotUndefined
+  );
+  const ingestors = [ingestIntoUniqueIndex, ingestIntoHashIndex].filter<
+    Ingestor<T>
+  >(isNotUndefined);
+
+  const captureObject: Captor<T> = (obj) => {
     const proxy = new Proxy(obj, {
       set(target: T, propName: never, newValue: any): boolean {
-        const isUpdating =
-          targetProperties.includes(propName) && target[propName] !== newValue;
-        // any update to ANY target property for all indexes
-        if (isUpdating) {
-          const oldSpecifierValue = target[propName] as never;
-          // now call the update handler for each active index
-        }
+        updaters.forEach((updateIndexFunc) =>
+          updateIndexFunc(proxy, propName, newValue)
+        );
         // @ts-ignore
         target[propName] = newValue;
         return true;
       },
     });
-    targetProperties.forEach((targetProperty) => {
-      const specifierValue = obj[targetProperty] as never;
-      // initial value setter for captured object
-    });
+    ingestors.forEach((ingestIntoIndex) => ingestIntoIndex(proxy));
 
     return proxy;
   };
 
-  return [
-    targetProperties.reduce<HashIndex<T, TargetProperties>>(
-      (acc, targetProperty) => {
-        acc[`${targetProperty}Index`] = {
-          get: (val) => {
-            const returnValue = indexes?.get(targetProperty)?.get(val);
-            if (!returnValue) {
-              throw new Error('ffs');
-            }
-            return returnValue;
-          },
-        };
-        return acc;
-      },
-      {}
-    ),
-    captorFunction,
-  ];
+  return [{ hash: hashIdx ?? {}, unique: uniqueIdx ?? {} }, captureObject];
+}
+
+function isNotUndefined<T>(element: any): element is T {
+  return element !== undefined;
+}
+
+function validateOptions<T extends IndexableObj>({ hash, unique }: Options<T>) {
+  if (hash === undefined || unique === undefined) {
+    return;
+  }
+  const combinedProps = [...hash.targetProperties, ...unique.targetProperties];
+  const deDupedProps = new Set(combinedProps);
+  if (deDupedProps.size !== combinedProps.length) {
+    const sharedProps = combinedProps.filter((prop) => deDupedProps.has(prop));
+    throw new ConfigurationError(
+      `Properties [${sharedProps}] used for both hash and unique index. A property must only be used in one type of index.`
+    );
+  }
 }

--- a/src/indexes/createIndexes.ts
+++ b/src/indexes/createIndexes.ts
@@ -1,0 +1,63 @@
+import { HashIndex, HashIndexOptions } from './hash';
+import {
+  Captor,
+  IndexableObj,
+  TargetProperties,
+  TargetProperty,
+} from './common';
+import { UniqueIndexOptions } from './uniqueHash';
+
+type Options = {
+  hash?: HashIndexOptions;
+  unique?: UniqueIndexOptions;
+};
+
+export function createIndexes<T extends IndexableObj>(
+  opts: Options
+): [HashIndex<T, TargetProperties>, Captor<T>] {
+  const { hash: hashOpts, unique: uniqueOpts } = opts;
+  // create the complete list of target properties
+  // instantiate the indexes
+
+  const captorFunction: Captor<T> = (obj) => {
+    const proxy = new Proxy(obj, {
+      set(target: T, propName: never, newValue: any): boolean {
+        const isUpdating =
+          targetProperties.includes(propName) && target[propName] !== newValue;
+        // any update to ANY target property for all indexes
+        if (isUpdating) {
+          const oldSpecifierValue = target[propName] as never;
+          // now call the update handler for each active index
+        }
+        // @ts-ignore
+        target[propName] = newValue;
+        return true;
+      },
+    });
+    targetProperties.forEach((targetProperty) => {
+      const specifierValue = obj[targetProperty] as never;
+      // initial value setter for captured object
+    });
+
+    return proxy;
+  };
+
+  return [
+    targetProperties.reduce<HashIndex<T, TargetProperties>>(
+      (acc, targetProperty) => {
+        acc[`${targetProperty}Index`] = {
+          get: (val) => {
+            const returnValue = indexes?.get(targetProperty)?.get(val);
+            if (!returnValue) {
+              throw new Error('ffs');
+            }
+            return returnValue;
+          },
+        };
+        return acc;
+      },
+      {}
+    ),
+    captorFunction,
+  ];
+}

--- a/src/indexes/hash.ts
+++ b/src/indexes/hash.ts
@@ -1,83 +1,77 @@
 import {
-  Captor,
   IndexableObj,
   IndexOptions,
-  TargetProperties,
+  Ingestor,
+  MissingIndex,
+  MissingIndexValue,
   TargetProperty,
+  Updater,
 } from './common';
 
-export type HashIndexOptions = IndexOptions;
-export type HashIndex<
-  T extends IndexableObj,
-  TargetProp extends Array<keyof T>
-> = Record<
+export type HashIndex<T extends IndexableObj> = Record<
   string,
   {
-    get: (value: T[TargetProp[0]]) => Set<T> | undefined;
+    get: (value: T[string]) => Set<T> | undefined;
   }
 >;
 
-export function createHashIndex<T extends IndexableObj>(
-  opts: HashIndexOptions
-): [HashIndex<T, TargetProperties>, Captor<T>] {
-  const { targetProperties } = opts;
-  const indexes = new Map<TargetProperty, Map<T[TargetProperty], Set<T>>>();
-  targetProperties.forEach((targetProperty) => {
-    indexes.set(targetProperty, new Map<T[TargetProperty], Set<T>>());
-  });
+export function createHashIndex<T extends IndexableObj>({
+  targetProperties,
+}: IndexOptions<T>): [HashIndex<T>, Updater<T>, Ingestor<T>] {
+  const indexes = initialiseIndex<T>(targetProperties);
 
-  const captorFunction: Captor<T> = (obj) => {
-    const proxy = new Proxy(obj, {
-      set(target: T, propName: never, newValue: any): boolean {
-        const isUpdating =
-          targetProperties.includes(propName) && target[propName] !== newValue;
-        if (isUpdating) {
-          const oldSpecifier = target[propName] as never;
-          const index = indexes.get(propName);
-          if (!index) {
-            throw new Error(`Index missing for property [${propName}]`);
-          }
-          const oldIndexValues = index.get(oldSpecifier);
-          if (!oldIndexValues) {
-            throw new Error(
-              `Object was not captured correctly, missing index for ${propName}:${oldSpecifier}`
-            );
-          }
-          oldIndexValues.delete(proxy);
-
-          insertIntoIndex(newValue, proxy, index);
-        }
-        // @ts-ignore
-        target[propName] = newValue;
-        return true;
-      },
-    });
+  const captureUpdate: Updater<T> = (obj, propName, newValue) => {
+    const oldValue = obj[propName] as T[string]; // ts is drunk
+    const isUpdating =
+      targetProperties.includes(propName) && oldValue !== newValue;
+    if (isUpdating) {
+      const index = indexes.get(propName);
+      if (!index) {
+        throw new MissingIndex(`Index missing for property [${propName}]`);
+      }
+      const oldIndexValues = index.get(oldValue);
+      if (!oldIndexValues) {
+        throw new MissingIndexValue(
+          `Object was not captured correctly, missing index value for ${propName}:${oldValue}`
+        );
+      }
+      oldIndexValues.delete(obj);
+      insertIntoIndex(newValue, obj, index);
+    }
+  };
+  const ingestObject: Ingestor<T> = (obj) => {
     targetProperties.forEach((targetProperty) => {
       const specifier = obj[targetProperty] as never;
       const index = indexes.get(targetProperty);
       if (!index) {
-        throw new Error(`Index missing for property [${targetProperty}]`);
+        throw new MissingIndex(
+          `Index missing for property [${targetProperty}]`
+        );
       }
-      insertIntoIndex(specifier, proxy, index);
+      insertIntoIndex(specifier, obj, index);
     });
-
-    return proxy;
   };
 
   return [
-    targetProperties.reduce<HashIndex<T, TargetProperties>>(
-      (acc, targetProperty) => {
-        acc[`${targetProperty}Index`] = {
-          get: (val) => {
-            return indexes?.get(targetProperty)?.get(val);
-          },
-        };
-        return acc;
-      },
-      {}
-    ),
-    captorFunction,
+    targetProperties.reduce<HashIndex<T>>((acc, targetProperty) => {
+      acc[`${targetProperty}Index`] = {
+        get: (val) => {
+          return indexes?.get(targetProperty)?.get(val);
+        },
+      };
+      return acc;
+    }, {}),
+    captureUpdate,
+    ingestObject,
   ];
+}
+
+function initialiseIndex<T extends IndexableObj>(targetProperties: string[]) {
+  const indexes = new Map<TargetProperty, Map<T[TargetProperty], Set<T>>>();
+  targetProperties.forEach((targetProperty) => {
+    indexes.set(targetProperty, new Map<T[TargetProperty], Set<T>>());
+  });
+  return indexes;
 }
 
 const insertIntoIndex = <T extends IndexableObj>(

--- a/src/indexes/index.ts
+++ b/src/indexes/index.ts
@@ -1,1 +1,8 @@
-export * from './hash';
+export * from './createIndexes';
+export {
+  IndexError,
+  MissingIndex,
+  MissingIndexValue,
+  ConfigurationError,
+} from './common';
+export { UniqueConstraintViolation } from './uniqueHash';

--- a/src/indexes/uniqueHash.ts
+++ b/src/indexes/uniqueHash.ts
@@ -6,7 +6,7 @@ import {
   TargetProperty,
 } from './common';
 
-export type HashIndexOptions = IndexOptions;
+export type UniqueIndexOptions = IndexOptions;
 export type HashIndex<
   T extends IndexableObj,
   TargetProp extends Array<keyof T>
@@ -17,8 +17,8 @@ export type HashIndex<
   }
 >;
 
-export function createHashIndex<T extends IndexableObj>(
-  opts: HashIndexOptions
+export function createUniqueHashIndex<T extends IndexableObj>(
+  opts: UniqueIndexOptions
 ): [HashIndex<T, TargetProperties>, Captor<T>] {
   const { targetProperties } = opts;
   const indexes = new Map<TargetProperty, Map<T[TargetProperty], Set<T>>>();

--- a/test/docs.test.ts
+++ b/test/docs.test.ts
@@ -1,14 +1,20 @@
 import { expect } from 'chai';
-import { createHashIndex } from '../src';
-import { performance } from 'perf_hooks';
+import { createIndexes } from '../src/indexes/createIndexes';
+import { UniqueConstraintViolation } from '../src/indexes/uniqueHash';
 
 type Order = { orderId: string; status: string; cost: number };
 
 describe('README.md examples', () => {
-  const [{ statusIndex: orderStatusIndex }, captureOrder] =
-    createHashIndex<Order>({
-      targetProperties: ['status'],
-    });
+  const [
+    {
+      hash: { statusIndex: orderStatusIndex },
+      unique: { orderIdIndex },
+    },
+    captureOrder,
+  ] = createIndexes<Order>({
+    hash: { targetProperties: ['status'] },
+    unique: { targetProperties: ['orderId'] },
+  });
   const exampleOrder = captureOrder({
     orderId: '123abc',
     status: 'PLACED',
@@ -16,72 +22,50 @@ describe('README.md examples', () => {
   });
   const placedOrders = orderStatusIndex.get('PLACED');
 
-  it('returns indexed objects', () => {
+  it('returns indexed objects from hash index', () => {
     expect(exampleOrder).to.eq(placedOrders?.values().next().value);
   });
-  it('updates indexes when values change', () => {
+  it('updates hash indexes when values change', () => {
     exampleOrder.status = 'SHIPPED';
     const shippedOrders = orderStatusIndex.get('SHIPPED');
 
     expect(placedOrders?.size).to.eq(0);
     expect(exampleOrder).to.eq(shippedOrders?.values().next().value);
   });
-  describe('Performance tests', function () {
-    const [{ statusIndex: orderStatusIndex }, captureOrder] = createHashIndex({
-      targetProperties: ['status'],
+  it('returns indexed object from unique index', () => {
+    expect(exampleOrder).to.eq(orderIdIndex.get('123abc'));
+  });
+  it('updates unique indexes when values change', () => {
+    exampleOrder.orderId = '456zyx';
+    expect(exampleOrder).to.eq(orderIdIndex.get('456zyx'));
+  });
+  it('throws when an object is captured that violates a unique constraint', () => {
+    captureOrder({
+      orderId: '1z2x3c',
+      status: 'PLACED',
+      cost: 100,
     });
-    const statusMap = {
-      0: 'PLACED',
-      1: 'SHIPPED',
-      2: 'DELIVERED',
-      3: 'CANCELLED',
-    } as const;
-    const allObjects = Array.from(
-      { length: 125_000 },
-      // @ts-ignore
-      (_, i) => captureOrder({ num: i, status: statusMap[i % 4] })
-    );
-    const placed = orderStatusIndex.get('PLACED');
-    it('looks up objects more than 1000x faster', () => {
-      const t0 = performance.now();
-      const shippedOld = Object.values(allObjects).filter(
-        ({ status }) => status === 'SHIPPED'
-      );
-      const t1 = performance.now();
-      const shipped = orderStatusIndex.get('SHIPPED');
-      const t2 = performance.now();
-      const vanillaLookupMs = t1 - t0;
-      const indexedLookupMs = t2 - t1;
-      const indexImprovementRatio = vanillaLookupMs / indexedLookupMs;
-      console.log(`Vanilla lookup: ${vanillaLookupMs}ms`);
-      console.log(`Indexed lookup: ${indexedLookupMs}ms`);
-      console.log(
-        `Index lookups are ${indexImprovementRatio.toFixed(0)} times faster`
-      );
-      expect(shipped?.size).to.eq(shippedOld.length);
-      expect(indexImprovementRatio).to.be.gte(1000); // Assert the index is at least 1,000 times faster
+    expect(() => {
+      captureOrder({
+        orderId: '1z2x3c',
+        status: 'PLACED',
+        cost: 100,
+      });
+    }).to.throw(UniqueConstraintViolation);
+  });
+  it('throws when an object is updated to violate a unique constraint', () => {
+    const obj = captureOrder({
+      orderId: '234',
+      status: 'PLACED',
+      cost: 100,
     });
-    it('updates are not more than twice as slow', () => {
-      const objToUpdate = allObjects[100_000];
-      expect(objToUpdate.status).to.eq('PLACED');
-      expect(placed?.size).to.eq(31_250);
-      const vanillaObjToUpdate = { num: 12345, status: 'PLACED' };
-      vanillaObjToUpdate.status = 'CANCELLED'; // Need to perform an update to force v8 to fully allocate the object
-      objToUpdate.status = 'CANCELLED';
-      const t0 = performance.now();
-      vanillaObjToUpdate.status = 'SHIPPED';
-      const t1 = performance.now();
-      objToUpdate.status = 'SHIPPED';
-      const t2 = performance.now();
-      const vanillaUpdateMs = t1 - t0;
-      const indexedUpdatedMs = t2 - t1;
-      const updateSlowdownRatio = indexedUpdatedMs / vanillaUpdateMs;
-      console.log(`Vanilla update: ${vanillaUpdateMs}ms`);
-      console.log(`Indexed update: ${indexedUpdatedMs}ms`);
-      console.log(`Updates are ${updateSlowdownRatio.toFixed(2)} times slower`);
-      expect(placed?.size).to.eq(31_249);
-      expect(objToUpdate).to.deep.eq({ num: 100_000, status: 'SHIPPED' });
-      expect(updateSlowdownRatio).to.be.lte(2);
+    captureOrder({
+      orderId: '345',
+      status: 'PLACED',
+      cost: 100,
     });
+    expect(() => {
+      obj.orderId = '345';
+    }).to.throw(UniqueConstraintViolation);
   });
 });

--- a/test/perf.test.ts
+++ b/test/perf.test.ts
@@ -1,0 +1,69 @@
+import { createIndexes } from '../src/indexes/createIndexes';
+import { performance } from 'perf_hooks';
+import { expect } from 'chai';
+
+type Order = { orderId: string; status: string; cost: number };
+
+describe('Performance tests', function () {
+  const [
+    {
+      hash: { statusIndex: orderStatusIndex },
+    },
+    captureOrder,
+  ] = createIndexes<Order>({
+    hash: { targetProperties: ['status'] },
+  });
+  const statusMap = {
+    0: 'PLACED',
+    1: 'SHIPPED',
+    2: 'DELIVERED',
+    3: 'CANCELLED',
+  } as const;
+  const allObjects = Array.from(
+    { length: 125_000 },
+    // @ts-ignore
+    (_, i) => captureOrder({ num: i, status: statusMap[i % 4] })
+  );
+  const placed = orderStatusIndex.get('PLACED');
+  it('looks up objects more than 1000x faster', () => {
+    const t0 = performance.now();
+    const shippedOld = Object.values(allObjects).filter(
+      ({ status }) => status === 'SHIPPED'
+    );
+    const t1 = performance.now();
+    const shipped = orderStatusIndex.get('SHIPPED');
+    const t2 = performance.now();
+    const vanillaLookupMs = t1 - t0;
+    const indexedLookupMs = t2 - t1;
+    const indexImprovementRatio = vanillaLookupMs / indexedLookupMs;
+    console.log(`Vanilla lookup: ${vanillaLookupMs}ms`);
+    console.log(`Indexed lookup: ${indexedLookupMs}ms`);
+    console.log(
+      `Index lookups are ${indexImprovementRatio.toFixed(0)} times faster`
+    );
+    expect(shipped?.size).to.eq(shippedOld.length);
+    expect(indexImprovementRatio).to.be.gte(1000); // Assert the index is at least 1,000 times faster
+  });
+  it('updates are not more than twice as slow', () => {
+    const objToUpdate = allObjects[100_000];
+    expect(objToUpdate.status).to.eq('PLACED');
+    expect(placed?.size).to.eq(31_250);
+    const vanillaObjToUpdate = { num: 12345, status: 'PLACED' };
+    vanillaObjToUpdate.status = 'CANCELLED'; // Need to perform an update to force v8 to fully allocate the object
+    objToUpdate.status = 'CANCELLED';
+    const t0 = performance.now();
+    vanillaObjToUpdate.status = 'SHIPPED';
+    const t1 = performance.now();
+    objToUpdate.status = 'SHIPPED';
+    const t2 = performance.now();
+    const vanillaUpdateMs = t1 - t0;
+    const indexedUpdatedMs = t2 - t1;
+    const updateSlowdownRatio = indexedUpdatedMs / vanillaUpdateMs;
+    console.log(`Vanilla update: ${vanillaUpdateMs}ms`);
+    console.log(`Indexed update: ${indexedUpdatedMs}ms`);
+    console.log(`Updates are ${updateSlowdownRatio.toFixed(2)} times slower`);
+    expect(placed?.size).to.eq(31_249);
+    expect(objToUpdate).to.deep.eq({ num: 100_000, status: 'SHIPPED' });
+    expect(updateSlowdownRatio).to.be.lte(2);
+  });
+});


### PR DESCRIPTION
You can now define multiple index types when creating indexes. The first of these
new indexes is a unique index that asserts that a value cannot be shared by any objects.

BREAKING CHANGE: The createHashIndex function is no longer available. All indexes must be created
using createIndexes