### PR TITLE
Fix deleteFromIndex bug in hash index

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,3 @@
+# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 20, 18, 16, 14, 18-bullseye, 16-bullseye, 14-bullseye, 18-buster, 16-buster, 14-buster
+ARG VARIANT=20-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,3 @@
 # [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 20, 18, 16, 14, 18-bullseye, 16-bullseye, 14-bullseye, 18-buster, 16-buster, 14-buster
-ARG VARIANT=20-bullseye
+ARG VARIANT=16-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,69 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.236.0/containers/javascript-node-postgres
+// Update the VARIANT arg in docker-compose.yml to pick a Node.js version
+{
+  "name": "Node.js & Docker-in-docker",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  "features": {
+    "ghcr.io/devcontainers-community/npm-features/prettier:1": {}
+  },
+  // Configure tool-specific properties.
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "esbenp.prettier-vscode",
+        "hbenl.vscode-mocha-test-adapter"
+      ],
+      "settings": {
+        "[typescript]": {
+          "editor.defaultFormatter": "esbenp.prettier-vscode",
+          "editor.formatOnSave": true
+        },
+        "[javascript]": {
+          "editor.defaultFormatter": "esbenp.prettier-vscode",
+          "editor.formatOnSave": true
+        },
+        "terminal.integrated.defaultProfile.linux": "zsh",
+        "terminal.integrated.profiles.linux": {
+          "bash": {
+            "path": "bash",
+            "icon": "terminal-bash"
+          },
+          "zsh": {
+            "path": "zsh"
+          },
+          "fish": {
+            "path": "fish"
+          },
+          "tmux": {
+            "path": "tmux",
+            "icon": "terminal-tmux"
+          },
+          "pwsh": {
+            "path": "pwsh",
+            "icon": "terminal-powershell"
+          }
+        }
+      }
+    }
+  },
+  "remoteEnv": {
+    // Configure env var so user-specific dot-files can configure project-specific settings
+    "WORKSPACE_FOLDER": "/workspaces/${localWorkspaceFolderBasename}"
+  },
+  "updateContentCommand": [
+    "bash",
+    "./bin/bootstrap.sh"
+  ],
+  "shutdownAction": "none"
+  // "features": {},
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+  // Use 'postCreateCommand' to run commands after the container is created.
+  // "postCreateCommand": "uname -a",
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
+}

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -1,0 +1,3 @@
+#! /usr/bin/env bash
+
+npm ci

--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
       "src/**/*.ts",
       "test/**/*.ts"
     ],
+    "spec": [
+      "test/**/*.ts"
+    ],
     "require": "ts-node/register"
   },
   "author": "Anthony Manning-Franklin <anthony.manning.franklin@gmail.com> (https://antman-does-software.com)",

--- a/test/docs.test.ts
+++ b/test/docs.test.ts
@@ -40,15 +40,20 @@ describe('README.md examples', () => {
     expect(exampleOrder).to.eq(orderIdIndex.get('456zyx'));
   });
   it('deletes entries from indexes', () => {
-    const delOrder =
-      captureOrder({
-        orderId: '90210',
-        status: 'PLACED',
-        cost: 120,
-      });
+    const delOrder = captureOrder({
+      orderId: '90210',
+      status: 'CANCELLED',
+      cost: 120,
+    });
+
+    expect(delOrder).to.eq(
+      orderStatusIndex.get('CANCELLED')?.values().next().value
+    );
     expect(delOrder).to.eq(orderIdIndex.get('90210'));
+
     delOrder.deleteFromIndex();
-    expect(orderIdIndex.get('90210')).to.eq(undefined)
+    expect(orderIdIndex.get('90210')).to.eq(undefined);
+    expect(orderStatusIndex.get('CANCELLED')?.size).eq(0);
   });
   it('throws when an object is captured that violates a unique constraint', () => {
     captureOrder({


### PR DESCRIPTION
## Problem
- The `deleteFromIndex` method in hash index has a bug.
```
const deleteFromIndex = <T extends IndexableObj>(
  specifier: T[string],
  target: T,
  index: Map<T[string], Set<T>>
): void => {
  index.get(specifier)?.delete(target);
};
```

- `index.get(specifier)` returns a Set containing the proxy objects matching this specifier
- However, the `target` object we pass into this function is the original object, not the proxy one

![Screenshot 2024-08-26 at 14 34 55](https://github.com/user-attachments/assets/3dbae54a-d0c0-49ec-b57d-f0d97035a85f)

- As a result, it fails to delete the target object from the set

## The fix
- Pass the proxy object instead of the original object to this delete method.
- Tested with both hash and unique index
- Also added Devcontainer files so it auto configures the dev environment and prettier
- Some file was reformatted, I changed only 1 place (check the comment)