### PR TITLE
Created getTarget() method which exposes the target and a noop indexer

### DIFF
--- a/src/indexes/common.ts
+++ b/src/indexes/common.ts
@@ -6,15 +6,14 @@ export type TargetProperty = string;
 export type IndexOptions<T extends IndexableObj> = {
   targetProperties: Properties;
 };
-export type Extension<T extends IndexableObj> = {
-  deleteFromIndex: () => void ;
-  // It looks like Omit<T & Extension<T>, keyof Extension<T>> might just equal T.
-  // But that's not true if T intersects with Extension eg T includes a field called 'deleteFromIndex' or 'getTarget'
-  // We could probably guard against this using a conditional type... but let's not get too carried away
-  getTarget: () => Omit<T & Extension<T>, keyof Extension<T>>;
-};
+export type IndexedObj<T extends IndexableObj> = Omit<T, 'deleteFromIndex' | 'getTarget' | 'isProxy'> &
+  {
+    deleteFromIndex: () => void;
+    getTarget: () => T;
+    isProxy: true;
+  }
 
-export type Captor<T extends IndexableObj> = (obj: T) => T & Extension<T>;
+export type Captor<T extends IndexableObj> = (obj: T) => IndexedObj<T>;
 export type Updater<T extends IndexableObj> = (
   obj: T,
   propName: string,

--- a/src/indexes/common.ts
+++ b/src/indexes/common.ts
@@ -6,10 +6,15 @@ export type TargetProperty = string;
 export type IndexOptions<T extends IndexableObj> = {
   targetProperties: Properties;
 };
-export type Extension = {
+export type Extension<T extends IndexableObj> = {
   deleteFromIndex: () => void ;
+  // It looks like Omit<T & Extension<T>, keyof Extension<T>> might just equal T.
+  // But that's not true if T intersects with Extension eg T includes a field called 'deleteFromIndex' or 'getTarget'
+  // We could probably guard against this using a conditional type... but let's not get too carried away
+  getTarget: () => Omit<T & Extension<T>, keyof Extension<T>>;
 };
-export type Captor<T extends IndexableObj> = (obj: T) => T & Extension;
+
+export type Captor<T extends IndexableObj> = (obj: T) => T & Extension<T>;
 export type Updater<T extends IndexableObj> = (
   obj: T,
   propName: string,

--- a/src/indexes/noop.ts
+++ b/src/indexes/noop.ts
@@ -1,24 +1,16 @@
-import {
-  Captor,
-  Extension,
-  IndexableObj,
-} from './common';
+import { Captor, IndexableObj, IndexedObj } from './common';
 
 
 export function createNoopCaptor<T extends IndexableObj>(): Captor<T> {
-  const captureObject: Captor<T> = (obj: T): T & Extension<T> => {
-    const extendedObject = Object.assign(obj, {
+  return (obj: T): IndexedObj<T> => {
+    return Object.assign({}, obj, {
       deleteFromIndex() {
         // No-op
       },
       getTarget() {
-        const {getTarget, deleteFromIndex, ...rest} = extendedObject;
-        return rest;
-      }
+        return obj;
+      },
+      isProxy: true as const,
     });
-
-    return extendedObject;
   };
-
-  return captureObject;
 }

--- a/src/indexes/noop.ts
+++ b/src/indexes/noop.ts
@@ -1,0 +1,24 @@
+import {
+  Captor,
+  Extension,
+  IndexableObj,
+} from './common';
+
+
+export function createNoopCaptor<T extends IndexableObj>(): Captor<T> {
+  const captureObject: Captor<T> = (obj: T): T & Extension<T> => {
+    const extendedObject = Object.assign(obj, {
+      deleteFromIndex() {
+        // No-op
+      },
+      getTarget() {
+        const {getTarget, deleteFromIndex, ...rest} = extendedObject;
+        return rest;
+      }
+    });
+
+    return extendedObject;
+  };
+
+  return captureObject;
+}


### PR DESCRIPTION
This change exposes the proxy target through a `getTarget()` method. This method can be used to eject the target object from it's proxy, allowing it to be copied by the structuredClone algorithm. This has become needed for serialising proxies and transferring proxies to workers.

While we could easily unwrap a proxy in consumers of this library by creating a copy and removing `deleteFromIndex`, it's a fragile approach and will break consumer implementations if we add more methods to the proxy index.

I also introduced a noop capture function (which SSP has currently implemented) for the same reason.