### PR TITLE
Fix functions and properties used to extend the proxy object being assigned to the proxy target

### DIFF
--- a/src/indexes/common.ts
+++ b/src/indexes/common.ts
@@ -6,7 +6,7 @@ export type TargetProperty = string;
 export type IndexOptions<T extends IndexableObj> = {
   targetProperties: Properties;
 };
-export type IndexedObj<T extends IndexableObj> = Omit<T, 'deleteFromIndex' | 'getTarget' | 'isProxy'> &
+export type IndexedObj<T extends IndexableObj> = T &
   {
     deleteFromIndex: () => void;
     getTarget: () => T;

--- a/test/docs.test.ts
+++ b/test/docs.test.ts
@@ -69,6 +69,15 @@ describe('README.md examples', () => {
     );
     expect(capturedOrder.getTarget()).to.eq(order);
     expect(capturedOrder.getTarget().status).to.eq('DISPATCHED');
+
+    // None of the methods added to extend the proxy should ever be assigned to
+    // the target.
+    // @ts-expect-error
+    expect(capturedOrder.getTarget().deleteFromIndex).to.eq(undefined);
+    // @ts-expect-error
+    expect(capturedOrder.getTarget().getTarget).to.eq(undefined);
+    // @ts-expect-error
+    expect(capturedOrder.getTarget().isProxy).to.eq(undefined);
   });
   it('reports its proxy status via isProxy', () => {
     const order = orderStatusIndex.get('SHIPPED')?.values().next().value;


### PR DESCRIPTION
## Problem/motivation

See the failing test in the first commit.

One of the problems with using `Object.assign` on the proxy is that those assignments are proxied straight through to the target.

None of `deleteFromIndex`, `getTarget` or `isProxy` makes sense to exist on the target from a type system perspective and neither method would produce an outcome, and `isProxy` would be a straight up lie.

## Solution

Use the `get` trap to add extended functionality to the instance of `Proxy`.

The other change required to get this to play nice with the type system was to change:

```diff
-export type IndexedObj<T extends IndexableObj> = Omit<T, 'deleteFromIndex' | 'getTarget' | 'isProxy'> &
+export type IndexedObj<T extends IndexableObj> = T &
```

This is because we no longer create an intermediary state where we have `proxy` which is a type of `T` and `extendedObject` which is a type of `IndexedObj<T>`, we only ever create one variable which is `IndexedObj<T>`.

By adding `Omit<T...`, the type system no longer allows `IndexedObj<T>` to be substituted into contexts where `T` is expected.

## Other solutions considered

* Extending the `Proxy` object - not possible because this is considered an "exotic object".
* Ignoring these properties in the `set` trap - this removes the properties from the proxy itself.